### PR TITLE
removed padding: 0; from nav

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -114,7 +114,6 @@ ul,
 ol {
   list-style-type: none;
   margin: 0;
-  padding: 0;
 }
  
 a {


### PR DESCRIPTION
Removed padding rule from ul, ol that negated browser added default padding for ul element in nav