### PR TITLE
Remove heading from inside address element

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -70,27 +70,32 @@
     <section class="contact-section">
       <div class="content-wrapper">
         <h2>Contact us, because you all need this.</h2>
-        <address class="contact-content">
+        <div class="contact-content">
           <div>
-            <h4>General Information</h4>
+          <h4>General Information</h4>
+          <address>
             <p>
               333 Main St, Lake Geneva, WI 53147<br>
               555-555-5555<br>
               hello@unplugged.com
             </p>
-          </div>
+          </address>
+        </div>
           <div>
             <h4>Chat with a Facilitator</h4>
-            <p>
-              555-555-5556<br>
-              facilitator@unplugged.com
-            </p>
+            <address>
+              <p>
+                555-555-5556<br>
+                facilitator@unplugged.com
+              </p>
+            </address>
           </div>
-        </address>
-        <!-- contact-content div ends -->
-      </div>
-      <!-- contact content wrapper ends -->
+          <!-- contact-content div ends -->
+        </div>
+        <!-- contact content wrapper ends -->
+        </div>
     </section>
+
   </main>
   <!-- main wrapper -->
 


### PR DESCRIPTION
The code as previously written had a heading inside an `<address>` element, which the validator was flagging as improper HTML. 

The markup has been changed to include two separate `<address>` elements around the paragraphs with the address information, leaving the headings outside of the address elements themselves. The previous `<address>` element that contained the class of `contact-content` has been replaced with a `div`, so that no CSS changes were necessary in order to maintain the existing styling.

![](https://cldup.com/redoJd_Wnr.png)
