### PR TITLE
CSS changes to remove redundant code

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -205,7 +205,6 @@ footer p {
 
 footer .content-wrapper {
   width: 55%;
-  margin: 50px 0;
 }
 
 footer .contact {
@@ -357,7 +356,7 @@ input[type=button] {
 .faq .content-wrapper {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   flex-flow: row wrap;
   margin: 50px 0 0 0;
 }
@@ -570,7 +569,6 @@ input[type=button] {
   /* Footer */
   footer .content-wrapper {
     width: 65%;
-    margin: 100px 0;
   }
 
   footer .footer-content {
@@ -604,7 +602,7 @@ input[type=button] {
   .mission-content {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
     padding-top: 20px;
   }
 
@@ -651,12 +649,14 @@ input[type=button] {
 @media only screen and (min-width:1200px) {
   /*Desktop styles here*/
 
-  header {
-    padding: 15px 0;
-  }
-
+  /* General styles */
   .content-wrapper {
     max-width: 960px;
+  }
+
+  /* Header */
+  header {
+    padding: 15px 0;
   }
 
   h2 {


### PR DESCRIPTION
Mobile
.faq .content-wrapper
Align-items: flex-start not center

footer .content-wrapper
Remove  margin: 50px 0; 

Tablet
.footer .content-wrapper
Remove margin: 100px 0;

.mission-content
Align-items: flex-start not center

Desktop
Move the content-wrapper code block so that it’s above the header code block
Add comments for general styles and header