### PR TITLE
CSS changes to remove redundant code

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -198,7 +198,7 @@ aside {
 .faq .content-wrapper {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   flex-flow: row wrap;
 }
 


### PR DESCRIPTION
Changes:
Mobile
.faq .content-wrapper
Align-items: flex-start not center