### PR TITLE
CSS changes to remove redundant code

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -146,7 +146,6 @@ footer p {
 
 footer .content-wrapper {
   width: 55%;
-  margin: 50px 0;
 }
 
 footer .contact {
@@ -258,7 +257,7 @@ aside {
 .faq .content-wrapper {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   flex-flow: row wrap;
   margin: 50px 0 0 0;
 }
@@ -390,6 +389,7 @@ aside {
   .header-divider {
     display: none;
   }
+
   /* Hero Area */
 
   /* Aside */
@@ -413,7 +413,7 @@ aside {
     flex-flow: column wrap;
     flex-basis: 50%;
   }
-  
+
   .features .features-item-description {
     width: 62%;
   }
@@ -431,7 +431,6 @@ aside {
   /* Footer */
   footer .content-wrapper {
     width: 65%;
-    margin: 100px 0;
   }
 
   .footer-content {
@@ -455,7 +454,7 @@ aside {
   .mission-content {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
     padding-top: 20px;
   }
 
@@ -476,7 +475,7 @@ aside {
   /* ==========================================================================
    FAQ Page
    ========================================================================== */
-  
+
   .faq .content-wrapper {
     justify-content: space-between;
   }
@@ -493,18 +492,20 @@ aside {
 @media only screen and (min-width:1200px) {
   /*Desktop styles here*/
 
-  header {
-    padding: 15px 0;
-  }
-
+  /* General styles */
   .content-wrapper {
     max-width: 960px;
+  }
+
+  /* Header */
+  header {
+    padding: 15px 0;
   }
 
   /* Hero */
   .hero-area h1 {
     width: 80%;
-}
+  }
 
   /* Aside */
   aside .content-wrapper {
@@ -525,7 +526,7 @@ aside {
   .features article {
     flex-basis: 33%;
   }
-  
+
   /* Reviews */
   .reviews article div {
     width: 42%;
@@ -537,7 +538,7 @@ aside {
 
   .mission h2,
   .contact-section .content-wrapper h2 {
-      width: 95%;
+    width: 95%;
   }
 
   /* ==========================================================================


### PR DESCRIPTION
Changes:
Mobile
.faq .content-wrapper
Align-items: flex-start not center

footer .content-wrapper
Remove  margin: 50px 0; 

Tablet
.footer .content-wrapper
Remove margin: 100px 0;

.mission-content
Align-items: flex-start not center

Desktop
Move the content-wrapper code block so that it’s above the header code block
Add comments for general styles and header