### PR TITLE
CSS changes to remove redundant code

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -145,7 +145,6 @@ footer p {
 
 footer .content-wrapper {
   width: 55%;
-  margin: 50px 0;
 }
 
 footer .contact {
@@ -257,7 +256,7 @@ aside {
 .faq .content-wrapper {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   flex-flow: row wrap;
   margin: 50px 0 0 0;
 }


### PR DESCRIPTION
Changes:
Mobile
.faq .content-wrapper
Align-items: flex-start not center

footer .content-wrapper
Remove  margin: 50px 0; 
